### PR TITLE
fix: stop propagating request to backend if not valid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-buffer</artifactId>
             <version>${gravitee-gateway-buffer.version}</version>

--- a/src/test/java/io/gravitee/policy/threatprotection/xml/XmlThreatProtectionPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/threatprotection/xml/XmlThreatProtectionPolicyTest.java
@@ -15,8 +15,7 @@
  */
 package io.gravitee.policy.threatprotection.xml;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.common.http.MediaType;
@@ -24,9 +23,12 @@ import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.api.stream.BufferedReadWriteStream;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.api.stream.SimpleReadWriteStream;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyResult;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -75,7 +77,7 @@ public class XmlThreatProtectionPolicyTest {
         when(request.headers()).thenReturn(HttpHeaders.create());
         ReadWriteStream<?> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNull(readWriteStream);
+        assertThat(readWriteStream).isNull();
     }
 
     @Test
@@ -83,10 +85,14 @@ public class XmlThreatProtectionPolicyTest {
         cut = new XmlThreatProtectionPolicy(configuration);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("<test valid=\"true\">value</test>"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isTrue();
 
         verifyZeroInteractions(policyChain);
     }
@@ -96,10 +102,14 @@ public class XmlThreatProtectionPolicyTest {
         cut = new XmlThreatProtectionPolicy(configuration);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("Invalid"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(any(PolicyResult.class));
     }
@@ -110,10 +120,14 @@ public class XmlThreatProtectionPolicyTest {
         cut = new XmlThreatProtectionPolicy(configuration);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("<test valid=\"true\">value</test>"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(any(PolicyResult.class));
     }
@@ -124,10 +138,13 @@ public class XmlThreatProtectionPolicyTest {
         cut = new XmlThreatProtectionPolicy(configuration);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("<test valid=\"false\">1234</test>"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(any(PolicyResult.class));
     }
@@ -138,7 +155,8 @@ public class XmlThreatProtectionPolicyTest {
         cut = new XmlThreatProtectionPolicy(configuration);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(
             Buffer.buffer(
@@ -146,6 +164,8 @@ public class XmlThreatProtectionPolicyTest {
             )
         );
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(any(PolicyResult.class));
     }
@@ -156,10 +176,13 @@ public class XmlThreatProtectionPolicyTest {
         cut = new XmlThreatProtectionPolicy(configuration);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("<test><child1></child1><child2></child2></test>"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(any(PolicyResult.class));
     }
@@ -170,10 +193,13 @@ public class XmlThreatProtectionPolicyTest {
         cut = new XmlThreatProtectionPolicy(configuration);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("<test><child><subChild></subChild></child></test>"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(any(PolicyResult.class));
     }
@@ -184,7 +210,8 @@ public class XmlThreatProtectionPolicyTest {
         cut = new XmlThreatProtectionPolicy(configuration);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(
             Buffer.buffer(
@@ -200,6 +227,8 @@ public class XmlThreatProtectionPolicyTest {
         );
         readWriteStream.end();
 
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
+
         verify(policyChain, times(1)).streamFailWith(any(PolicyResult.class));
     }
 
@@ -209,7 +238,8 @@ public class XmlThreatProtectionPolicyTest {
         cut = new XmlThreatProtectionPolicy(configuration);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(
             Buffer.buffer(
@@ -217,6 +247,8 @@ public class XmlThreatProtectionPolicyTest {
             )
         );
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(any(PolicyResult.class));
     }
@@ -227,10 +259,13 @@ public class XmlThreatProtectionPolicyTest {
         cut = new XmlThreatProtectionPolicy(configuration);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("<test><element1 /><element2 /><element3 /></test>"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(any(PolicyResult.class));
     }
@@ -241,7 +276,8 @@ public class XmlThreatProtectionPolicyTest {
         cut = new XmlThreatProtectionPolicy(configuration);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         // Perform an injection of logback xml file.
         String path = getClass().getResource("/logback-test.xml").getPath();
@@ -257,6 +293,23 @@ public class XmlThreatProtectionPolicyTest {
         );
         readWriteStream.end();
 
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
+
         verify(policyChain, times(1)).streamFailWith(any(PolicyResult.class));
+    }
+
+    /**
+     * Replace the endHandler of the resulting ReadWriteStream of the policy execution.
+     * This endHandler will set an {@link AtomicBoolean} to {@code true} if its called.
+     * It will allow us to verify if super.end() has been called on {@link BufferedReadWriteStream#end()}
+     * @param readWriteStream: the {@link ReadWriteStream} to modify
+     * @return an AtomicBoolean set to {@code true} if {@link SimpleReadWriteStream#end()}, else {@code false}
+     */
+    private AtomicBoolean spyEndHandler(ReadWriteStream readWriteStream) {
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = new AtomicBoolean(false);
+        readWriteStream.endHandler(__ -> {
+            hasCalledEndOnReadWriteStreamParentClass.set(true);
+        });
+        return hasCalledEndOnReadWriteStreamParentClass;
     }
 }


### PR DESCRIPTION
Issue

https://github.com/gravitee-io/issues/issues/7301

Description

TransformableReadWriteStream will systematically do a call on write() and end() on the parent implementation when applying transformation method. It causes the chain to execute and propagate to backend even if we want to make the chain fail.

- Replace usage of TransformableRequestStreamBuilder by BufferedReadWriteStream to control if we have to write() and end() the stream. We continue the request only if xml is valid
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.1-issues-7301-stop-propagate-request-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-xml-threat-protection/1.3.1-issues-7301-stop-propagate-request-SNAPSHOT/gravitee-policy-xml-threat-protection-1.3.1-issues-7301-stop-propagate-request-SNAPSHOT.zip)
  <!-- Version placeholder end -->
