### PR TITLE
Do not resolve external entities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,17 +30,19 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>21.0.0</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>1.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.9.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.17.2</gravitee-common.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.18.12</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-bom.version>3.0.0</gravitee-bom.version>
+        <gravitee-common.version>1.28.0</gravitee-common.version>
+        <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>
+        <gravitee-gateway-api.version>1.37.0</gravitee-gateway-api.version>
+        <gravitee-node.version>1.27.9</gravitee-node.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <junit.version>4.12</junit.version>
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
-        <gravitee-gateway-buffer.version>3.0.17</gravitee-gateway-buffer.version>
         <woodstox.version>6.2.1</woodstox.version>
         <guava.version>30.1.1-jre</guava.version>
         <!-- Property used by the publication job in CI-->
@@ -113,17 +115,15 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.gravitee.gateway</groupId>
-            <artifactId>gravitee-gateway-buffer</artifactId>
-            <version>${gravitee-gateway-buffer.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/policy/threatprotection/xml/XmlThreatProtectionPolicy.java
+++ b/src/main/java/io/gravitee/policy/threatprotection/xml/XmlThreatProtectionPolicy.java
@@ -34,6 +34,7 @@ import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyConfiguration;
 import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.api.annotations.OnRequestContent;
+import java.io.InputStream;
 import java.io.StringReader;
 import java.time.Duration;
 import java.util.Collections;
@@ -41,6 +42,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLResolver;
 import javax.xml.stream.XMLStreamException;
 
 /**
@@ -137,6 +139,15 @@ public class XmlThreatProtectionPolicy {
                 configuration,
                 () -> {
                     XMLInputFactory xmlFactory = new WstxInputFactory();
+                    xmlFactory.setXMLResolver(
+                        new XMLResolver() {
+                            @Override
+                            public Object resolveEntity(String publicID, String systemID, String baseURI, String namespace)
+                                throws XMLStreamException {
+                                return InputStream.nullInputStream();
+                            }
+                        }
+                    );
                     xmlFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, configuration.isAllowExternalEntities());
                     setXmlFactoryProperty(xmlFactory, WstxInputProperties.P_MAX_ATTRIBUTE_SIZE, configuration.getMaxAttributeValueLength());
                     setXmlFactoryProperty(xmlFactory, WstxInputProperties.P_MAX_TEXT_LENGTH, configuration.getMaxTextValueLength());

--- a/src/main/java/io/gravitee/policy/threatprotection/xml/XmlThreatProtectionPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/threatprotection/xml/XmlThreatProtectionPolicyConfiguration.java
@@ -69,7 +69,7 @@ public class XmlThreatProtectionPolicyConfiguration implements PolicyConfigurati
     private Integer maxEntityDepth;
 
     /**
-     * Wheter to allow external entities or not.
+     * Whether to allow external entities or not.
      * Default is false.
      */
     private boolean allowExternalEntities = false;


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2081

**Description**

Previously, the XML parser was resolving external entities which makes the policy vulnerable to XXE attack such as https://www.acunetix.com/blog/articles/band-xml-external-entity-oob-xxe/
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.3-APIM-2081-resolve-external-entities-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-xml-threat-protection/1.3.3-APIM-2081-resolve-external-entities-SNAPSHOT/gravitee-policy-xml-threat-protection-1.3.3-APIM-2081-resolve-external-entities-SNAPSHOT.zip)
  <!-- Version placeholder end -->
