### PR TITLE
chore: update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,14 +34,14 @@
     </parent>
 
     <properties>
-        <gravitee-apim-gateway-tests-sdk.version>3.18.12</gravitee-apim-gateway-tests-sdk.version>
-        <gravitee-bom.version>5.0.0</gravitee-bom.version>
-        <gravitee-common.version>1.28.0</gravitee-common.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.20.28</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-bom.version>3.0.22</gravitee-bom.version>
+        <gravitee-common.version>2.3.0</gravitee-common.version>
         <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>
-        <gravitee-gateway-api.version>1.37.0</gravitee-gateway-api.version>
-        <gravitee-node.version>1.27.9</gravitee-node.version>
+        <gravitee-gateway-api.version>2.0.3</gravitee-gateway-api.version>
+        <gravitee-node.version>2.1.0</gravitee-node.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <junit.version>4.12</junit.version>
+
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <woodstox.version>6.2.1</woodstox.version>
         <guava.version>30.1.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <woodstox.version>6.6.0</woodstox.version>
+        <wiremock.version>3.3.1</wiremock.version>
         <guava.version>32.1.2-jre</guava.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
@@ -120,13 +121,24 @@
             <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
             <version>${gravitee-apim-gateway-tests-sdk.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.wiremock</groupId>
+                    <artifactId>wiremock-jre8</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>${wiremock.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <woodstox.version>6.2.1</woodstox.version>
-        <guava.version>30.1.1-jre</guava.version>
+        <guava.version>32.1.2-jre</guava.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
-        <woodstox.version>6.2.1</woodstox.version>
+        <woodstox.version>6.6.0</woodstox.version>
         <guava.version>32.1.2-jre</guava.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>

--- a/src/test/java/io/gravitee/policy/threatprotection/xml/XmlThreatProtectionPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/threatprotection/xml/XmlThreatProtectionPolicyTest.java
@@ -20,8 +20,6 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.gateway.api.Request;


### PR DESCRIPTION
**Description**

Upgrade all Gravitee dependencies using the version defined in the latest 3.20.
Upgrade woodstox



**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.1-bump-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-xml-threat-protection/1.5.1-bump-dependencies-SNAPSHOT/gravitee-policy-xml-threat-protection-1.5.1-bump-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
